### PR TITLE
Fix initial toggle if default light mode

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -11,6 +11,8 @@
         ? Boolean(storageValue)
         : window?.matchMedia('(prefers-color-scheme: light)').matches
 
+      localStorage.setItem('prefersLight', prefersLight)
+
       // default to dark mode unless explicitly set preference to light
       if (prefersLight) {
         document.querySelector('html').classList.remove('dark')


### PR DESCRIPTION
Resolved an issue where on first load of the page when default prefersLight mode is true, the toggle button would be in the incorrect mode.

Scenario:
* Have default OS set to light
* load the page, ensure local storage is cleared, if not clear it and refresh

Result:
* Toggle button looks like the sun and if you click it, you stay in light mode

Expected:
* Toggles to dark mode