### PR TITLE
Add custom preview as a new feature

### DIFF
--- a/posts/getting-started/index.md
+++ b/posts/getting-started/index.md
@@ -28,7 +28,7 @@ You can add a new post by creating either a new `.md` file or a folder with an `
 /posts/my-first-post/index.md
 ```
 
-Make sure your posts have `title` and `date` properties in the frontmatter:
+Make sure your posts have `title` and `date` properties in the front matter:
 
 ```md
 ---

--- a/posts/getting-started/index.md
+++ b/posts/getting-started/index.md
@@ -34,10 +34,13 @@ Make sure your posts have `title` and `date` properties in the frontmatter:
 ---
 title: My First Post
 date: 2021-07-09
+preview: This text will be used for the preview instead of the first paragraph 
 ---
 
 (your content here)
 ```
+
+The `preview` property is optional, in case you want to customize the preview text. If the property is added, but the text is left empty, the first paragraph is used automatically.
 
 ---
 

--- a/src/lib/get-posts.js
+++ b/src/lib/get-posts.js
@@ -50,7 +50,8 @@ const posts = Object.entries(import.meta.globEager('/posts/**/*.md'))
         : undefined,
 
       // the svelte component
-      component: post.default
+      component: post.default,
+      customPreview: post.metadata.preview
     }
   })
   // parse HTML output for content metadata (preview, reading time, toc)
@@ -58,7 +59,7 @@ const posts = Object.entries(import.meta.globEager('/posts/**/*.md'))
     const parsedHtml = parse(post.component.render().html)
 
     // get the first paragaph of the post to use for the preview
-    const preview = parsedHtml.querySelector('p')
+    const preview = post.customPreview? post.customPreview : parsedHtml.querySelector('p')
 
     return {
       ...post,

--- a/src/lib/get-posts.js
+++ b/src/lib/get-posts.js
@@ -58,7 +58,7 @@ const posts = Object.entries(import.meta.globEager('/posts/**/*.md'))
   .map((post) => {
     const parsedHtml = parse(post.component.render().html)
 
-    // get the first paragraph of the post to use for the preview
+    // Use the custom preview in the metadata, if availabe, or the first paragraph of the post for the preview
     const preview = post.customPreview? post.customPreview : parsedHtml.querySelector('p')
 
     return {

--- a/src/lib/get-posts.js
+++ b/src/lib/get-posts.js
@@ -58,7 +58,7 @@ const posts = Object.entries(import.meta.globEager('/posts/**/*.md'))
   .map((post) => {
     const parsedHtml = parse(post.component.render().html)
 
-    // get the first paragaph of the post to use for the preview
+    // get the first paragraph of the post to use for the preview
     const preview = post.customPreview? post.customPreview : parsedHtml.querySelector('p')
 
     return {


### PR DESCRIPTION
Hey,

I started to use your template today. Thanks for the great work. 
I did not like the content of the preview for one post of mine, because the first paragraph was not suitable for a preview.
So I added this as additional feature.

### Usage
Add the property `preview` to the metadata of the post.

### Example of how to add a custom preview in the markdown file metadata
```
---
title: Lorem Ipsum!
date: 2022-02-11
preview: This is a custom preview. I now can optionally add content or thoughts from other paragraphs than just the first one. Or I can edit the first paragraph so it makes a better preview than the actual content.
---
```

Hope you like the idea. If I should change anything please let me know or simply reject this PR.

### Rendered result of the post with Lorem Ipsum without the custom preview text

<img width="633" alt="Screenshot 2022-02-11 at 19 53 52" src="https://user-images.githubusercontent.com/9088722/153652987-b8730251-6a4d-4009-82c4-61683caa8081.png">

<img width="1144" alt="Screenshot 2022-02-11 at 19 54 00" src="https://user-images.githubusercontent.com/9088722/153652980-2b3878fc-f0f9-45db-aa99-b4d81ab08760.png">

